### PR TITLE
Capture job stdout

### DIFF
--- a/{{cookiecutter.profile_name}}/grid-submit.py
+++ b/{{cookiecutter.profile_name}}/grid-submit.py
@@ -21,6 +21,7 @@ sub = htcondor.Submit({
     'arguments':    jobscript,
     'max_retries':  '5',
     'log':          join(jobDir, 'condor.log'),
+    'output':       join(jobDir, 'condor.out'),
     'error':        join(jobDir, 'condor.err'),
     'getenv':       'True',
     'request_cpus': str(job_properties['threads']),


### PR DESCRIPTION
Adds submit config for capturing job stdout. This can be useful for debugging, and seems like a sane default.

If there are concerns about pulling back output from jobs that produce too much noise on stdout, perhaps this could optionally be disabled through job properties?