### PR TITLE
Added config.v8.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 This profile configures Snakemake to submit jobs to a HTCondor cluster.
 
 ### Prerequisites
-The profile makes use of the HTCondor python bindings which can be installed with 
+The profile makes use of the HTCondor python bindings (and  `snakemake-executor-plugin-cluster-generic` for snakemake > 8) which can be installed with 
 
-    pip install --user htcondor
+    pip install --user htcondor snakemake-executor-plugin-cluster-generic 
     
 or using Anaconda with
 
-    conda install -c conda-forge python-htcondor
+    conda install -c conda-forge -c bioconda python-htcondor snakemake-executor-plugin-cluster-generic
 
 ### Deploy profile
 
@@ -39,3 +39,6 @@ Because the tests will try to submit jobs they need to be started from a HTCondo
 ```
 DOCKER_COMPOSE=tests/docker-compose.yaml ./tests/deploystack.sh
 ```
+
+## Migration to snakemake v8
+If using snakemake version 8 or higher, refer to [the migration guide](https://snakemake.readthedocs.io/en/stable/getting_started/migration.html). For this profile, use `config.v8+.yaml` instead of `config.yaml`

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -15,3 +15,4 @@ dependencies:
   - pyflakes
   - urllib3
   - cryptography
+  - snakemake-executor-plugin-cluster-generic

--- a/{{cookiecutter.profile_name}}/config.v8+.yaml
+++ b/{{cookiecutter.profile_name}}/config.v8+.yaml
@@ -1,0 +1,10 @@
+jobscript: "grid-jobscript.sh"
+executor: "cluster-generic"
+cluster-generic-status-cmd: "grid-status.py"
+cluster-generic-submit-cmd: "grid-submit.py"
+max-jobs-per-second: 100
+max-status-checks-per-second: 100
+restart-times: 5
+local-cores: 10
+jobs: 5000
+verbose: false


### PR DESCRIPTION
Fixes #18. Still need to look at the tests for both snakemake <8 and >8. I guess I could add a [matrix](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs) for the github actions but I'm not sure the best way beyond `tox` of going about doing it locally. I also use podman which doesn't have `docker-swarm` which makes it difficult to test locally. It seems to work on the cluster I use at least.