### PR TITLE
feat: Add CERN kerberos auth with 'location_cern' option

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,4 +1,5 @@
 {
     "profile_name": "htcondor",
-    "htcondor_log_dir": "/net/data_lhcb1b/user/jheuel/.condor_jobs"
+    "htcondor_log_dir": "/net/data_lhcb1b/user/jheuel/.condor_jobs",
+    "location_cern": false
 }

--- a/{{cookiecutter.profile_name}}/grid-submit.py
+++ b/{{cookiecutter.profile_name}}/grid-submit.py
@@ -37,6 +37,16 @@ request_disk = job_properties["resources"].get("disk_mb", None)
 if request_disk is not None:
     sub["request_disk"] = str(request_disk)
 
+{%- if cookiecutter.location_cern %}
+
+# Add kerberos credentials
+# c.f. https://batchdocs.web.cern.ch/local/pythonapi.html
+col = htcondor.Collector()
+credd = htcondor.Credd()
+credd.add_user_cred(htcondor.CredTypes.Kerberos, None)
+sub["MY.SendCredential"] = "True"
+{%- endif %}
+
 schedd = htcondor.Schedd()
 clusterID = schedd.submit(sub)
 


### PR DESCRIPTION
Resolves #21 

Add `location_cern` option to add snippet from https://github.com/Snakemake-Profiles/htcondor/issues/15#issuecomment-1781299029 if running on CERN's lxbatch system.