### PR TITLE
docs: Use cookiecutter CLI API to avoid cd

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ or using Anaconda with
 To deploy this profile run
 
     mkdir -p ~/.config/snakemake
-    cd ~/.config/snakemake
-    cookiecutter https://github.com/Snakemake-Profiles/htcondor.git
+    cookiecutter --output-dir ~/.config/snakemake gh:Snakemake-Profiles/htcondor
 
 You will be asked for the name of the profile and for a path where the HTCondor logs will be stored. 
 The logs will be used to update the status of submitted jobs (as recommended in the [documentation of the HTCondor Python bindings](https://htcondor.readthedocs.io/en/latest/apis/python-bindings/tutorials/Scalable-Job-Tracking.html)).


### PR DESCRIPTION
* Use '--output-dir' to avoid having to cd into a directory to use cookiecutter there.
* Use 'gh' abbreviation for GitHub.
   - c.f. https://cookiecutter.readthedocs.io/en/2.6.0/usage.html#works-directly-with-git-and-hg-mercurial-repos-too